### PR TITLE
Spare scoring function

### DIFF
--- a/Bowling/bowling_game_test.c
+++ b/Bowling/bowling_game_test.c
@@ -34,6 +34,7 @@ static void test_gutter_game()
 //Test the scenario where 1 ball falls at every try
 static void test_all_ones()
 {
+    bowling_game_init();
     //Total 20 tries with one falling pin everytime
     roll_many(20, 1);
 


### PR DESCRIPTION
The function sums over all tries, without hopping frames and then checks divisibility by 2 to get the first try of each frame. Using this and bounding over max number of roll we finally score the spare.